### PR TITLE
Add Circle and Square company blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ Collection of links for every Android developer
 
 
 ## Company Blogs
+- [Circle](http://engineering.circle.com/tag/android/)
 - [Facebook](https://code.facebook.com/android/)
 - [Instagram](http://instagram-engineering.tumblr.com/tagged/android)
+- [Square](https://corner.squareup.com/)
 
 
 ## Library repos


### PR DESCRIPTION
Square is almost single-handedly pushing the art of Android development
forward.
Circle has only posted one Android post so far, but it was a solid post

PS I just realized that they are both shape names. lol
